### PR TITLE
enforces widths of first 2 columns in leaderboards + hides ranks of consecutive players with similar points

### DIFF
--- a/src/components/ranking/MSLRanking.css
+++ b/src/components/ranking/MSLRanking.css
@@ -5,22 +5,33 @@
 #mslrankings-table {
     margin-left: auto;
     margin-right: auto;
-    text-align: left;
+    text-align: center;
     background-color: transparent;
     color: white;
+    width: 100%;
+    word-break: break-all;
 }
 
-#mslrankings-table tr td:nth-child(-n+8):nth-child(n+3){
-    text-align: center;
+#mslrankings-table tr td:nth-child(2){
+    text-align: left;
 }
 
-#mslrankings-table tr th:nth-child(-n+8):nth-child(n+3){
-    text-align: center;
+#mslrankings-table colgroup col:nth-child(1){
+    width: 10%;
+}
+
+#mslrankings-table colgroup col:nth-child(2){
+    width: 25%;
+}
+
+#mslrankings-table tr th:nth-child(2){
+    text-align: left;
 }
 
 #ranking-row-header > th {
     text-transform: capitalize;
     color: white;
+    text-align: center;
 }
 
 #placeholder-table-while-mslrankings-are-loading {

--- a/src/components/ranking/MSLRanking.js
+++ b/src/components/ranking/MSLRanking.js
@@ -74,15 +74,20 @@ function makeKey(type, mode, region) {
 
 export function trimToValidRankingsOnly(rankings) {
     const whiteListedColumns = ["PLACE", "PLAYER", "POINTS", "SUMMER SPLIT", "FALL SPLIT", "FALL SPLIT 2"];
+    const placeIndex = 0;
+    const pointsIndex = 2;
     if (rankings && rankings.length > 0) {
         const first2Keys = extractFirst2Keys(rankings[0]);
-        return rankings.filter((r) =>
+        const filteredRankings = rankings.filter((r) =>
             first2Keys.reduce((aggr, k) => r[k] ? ++aggr : aggr, 0) >= 2
-        ).map((r) => {
+        );
+        const pointsKey = Object.keys(filteredRankings ? filteredRankings[0] : {}).find((k) => k.toUpperCase() === whiteListedColumns[pointsIndex]);
+        return filteredRankings.map((r, i) => {
             var newR = {};
-            Object.keys(r).forEach((k) => {
+            Object.keys(r).forEach((k, keyIndex) => {
                 if (k && whiteListedColumns.includes(k.trim().toUpperCase())) {
-                    newR[k] = r[k];
+                    // console.log(`compare(r[pointsKey]=${r[pointsKey]}, filteredRankings[i-1][pointsKey]=${i > 0 ? filteredRankings[i-1][pointsKey] : ""})`);
+                    newR[k] = (keyIndex === placeIndex && i > 0 && pointsKey && r[pointsKey] === filteredRankings[i-1][pointsKey]) ? "" : r[k];
                 }
             });
             return newR;
@@ -108,6 +113,7 @@ function buildRankingTable(isLoading, rankings) {
         <div className="box">
             <div className="table-container">
                 <table className="table is-fullwidth is-fullheight is-narrow" id={"mslrankings-table"}>
+                    {buildRankingTableColGroup(isLoading, validRankings)}
                     <thead>
                     {buildRankingTableHeader(isLoading, validRankings)}
                     </thead>
@@ -118,6 +124,22 @@ function buildRankingTable(isLoading, rankings) {
             </div>
         </div>
     </div>
+}
+
+function buildRankingTableColGroup(isLoading, rankings) {
+    if (isLoading || !rankings || rankings.length === 0) {
+        return <colgroup>
+                <col span="1"/>
+                <col span="2"/>
+                <col span="3"/>
+                <col span="4"/>
+                <col span="5"/>
+            </colgroup>
+    } else {
+        return <colgroup>
+            {Object.keys(rankings[0]).map(k => <col span={k} />)}
+        </colgroup>
+    }
 }
 
 function buildRankingTableHeader(isLoading, rankings) {

--- a/src/components/ranking/MSLRanking.test.js
+++ b/src/components/ranking/MSLRanking.test.js
@@ -51,13 +51,13 @@ describe("trimToValidRankingsOnly", () => {
         }, {
             "Place": "3",
             "": "",
-            "Player": "",
-            "Points": "",
-            "SUMMER R1": "",
-            "SUMMER R2": "",
+            "Player": "Fierryy",
+            "Points": "361",
+            "SUMMER R1": "250",
+            "SUMMER R2": "111",
             "SUMMER R3": "",
             "SUMMER MAJOR": "",
-            "Summer Split": "",
+            "Summer Split": "361",
             "FALL R1": "",
             "FALL R2": "",
             "FALL R3": "",
@@ -101,6 +101,13 @@ describe("trimToValidRankingsOnly", () => {
             }, {
                 "Place": "2",
                 "Player": "HQdaan",
+                "Points": "361",
+                "Summer Split": "361",
+                "Fall Split": "",
+                "Fall Split 2": ""
+            }, {
+                "Place": "",
+                "Player": "Fierryy",
                 "Points": "361",
                 "Summer Split": "361",
                 "Fall Split": "",

--- a/src/components/ranking/ranking.css
+++ b/src/components/ranking/ranking.css
@@ -11,6 +11,16 @@
     margin-right: auto;
     background-color: transparent;
     color: white;
+    width: 100%;
+    word-break: break-all;
+}
+
+#rankings-table colgroup col:nth-child(1){
+    width: 10%;
+}
+
+#rankings-table colgroup col:nth-child(2){
+    width: 25%;
 }
 
 #rankings-table th {

--- a/src/components/ranking/ranking.js
+++ b/src/components/ranking/ranking.js
@@ -1,6 +1,6 @@
 import "./ranking.css";
 
-import axios from "axios"
+import axios from "axios";
 import React, {useEffect, useState} from "react";
 import sms_peach_img from "../../assets/sms.peach.bw.png";
 import msc_peach_img from "../../assets/msc.peach.bw.png";
@@ -89,6 +89,13 @@ function buildRankingTable(isLoading, rankings) {
         <div className="box">
             <div className="table-container">
                 <table className="table is-fullwidth is-fullheight is-narrow" id={"rankings-table"}>
+                    <colgroup>
+                        <col span="1"/>
+                        <col span="2"/>
+                        <col span="3"/>
+                        <col span="4"/>
+                        <col span="5"/>
+                    </colgroup>
                     <thead>
                     <tr>
                         <th>#</th>


### PR DESCRIPTION
- Leaderboards no longer have dynamically sized columns, both on web & mobile
- `Rank` column centered
- Hide rank of subsequent players with same amount of points

<img width="1660" alt="Screenshot 2022-08-08 at 10 05 46 PM" src="https://user-images.githubusercontent.com/104911913/183473362-bd4aa894-dd1d-4e8d-9d7e-f6adba638fda.png">

![IMG_7722](https://user-images.githubusercontent.com/104911913/183473772-576c62a3-c5ca-4a00-af00-43145f5b75e5.PNG)

![IMG_7723](https://user-images.githubusercontent.com/104911913/183473809-6de3ba7b-b595-4432-928b-a638c24ba991.PNG)

